### PR TITLE
replaced download filename string with original upload filename

### DIFF
--- a/src/ibl/iblSpecularEffect.ts
+++ b/src/ibl/iblSpecularEffect.ts
@@ -100,7 +100,11 @@ export class IBLSpecularEffect {
         polynomialPromise.then(() => {
             EnvironmentTextureTools.CreateEnvTextureAsync(babylonTexture).then((buffer: ArrayBuffer) => {
                 const blob = new Blob([buffer], { type: "octet/stream" });
-                Tools.Download(blob, "environment.env");
+                // Remove 'file:' prefix.
+                const name = texture.name.split(':').pop() || 'environment';
+                // Remove file extension.
+                const fileName = name.split('.').shift();
+                Tools.Download(blob, `${fileName}.env`);
             })
             .catch((error: unknown) => {
                 console.error(error);


### PR DESCRIPTION
This is a PR to change the output filename from "environment" to the original file input name.

`app.ts` sets the name of the textures. I did originally think of passing the original filename in the texture's metadata but went with this method to keep changes minimal.