### PR TITLE
Add dominant direction to irradiance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@babylonjs/core": "^8.0.1"
+                "@babylonjs/core": "^8.12.1"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^8.16.0",
@@ -29,9 +29,10 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.0.1.tgz",
-            "integrity": "sha512-00XJJgKJSLPY9eOE4MPZWqSxtifZS0oiKZyHKmybnXdYDtXCmh4ehyL2vguaE8MP1lqQEJ7RTC7gqP7ru/7vjw=="
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.12.1.tgz",
+            "integrity": "sha512-qw5B3DxNKXoOTY0WFkZmQnodbmgkUh41OXHa8DBMIUwfz+28DA4xTG8jsN+glrIZo/+gMM28m772bQ9BZ56Z7A==",
+            "license": "Apache-2.0"
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "devServer": "npx webpack-dev-server --config webpack.dev.js"
     },
     "dependencies": {
-        "@babylonjs/core": "^8.9.1"
+        "@babylonjs/core": "^8.12.1"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "devServer": "npx webpack-dev-server --config webpack.dev.js"
     },
     "dependencies": {
-        "@babylonjs/core": "^8.0.1"
+        "@babylonjs/core": "^8.9.1"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -285,7 +285,7 @@ const loadFiles = function(event: any): void {
                     generateSpecularIBL();
                 }, () => {
                     console.log("Error loading HDR file");
-                }, false, generateIrradiance, generateIrradiance);
+                }, true, generateIrradiance, generateIrradiance);
                 return;
             }
             else if (extension === "jpg" || extension === "png") {

--- a/src/ibl/iblDiffuseFragment.glsl
+++ b/src/ibl/iblDiffuseFragment.glsl
@@ -41,7 +41,7 @@ void main()
     }
     dir = normalize(dir);
 
-    vec3 integratedBRDF = irradiance(environmentMap, dir, textureInfo, icdf);
+    vec3 integratedBRDF = irradiance(environmentMap, dir, textureInfo, 0.0, vec3(1.0), dir, icdf);
 
     gl_FragColor = vec4(integratedBRDF, 1.);
 }

--- a/src/textureTools/textureTools.ts
+++ b/src/textureTools/textureTools.ts
@@ -83,8 +83,11 @@ export class TextureTools {
      */
     public renderDiffuseIBL(texture: BaseTexture): void {
         this._cdfGenerator.onGeneratedObservable.addOnce(() => {
-            this._iblDiffuseEffect.render(texture, this._cdfGenerator.getIcdfTexture());
-            this._blitCubeEffect.blit(this._iblDiffuseEffect.rtw, 0);
+            this._cdfGenerator.findDominantDirection().then((direction) => {
+                this._iblDiffuseEffect.render(texture, this._cdfGenerator.getIcdfTexture());
+                this._blitCubeEffect.blit(this._iblDiffuseEffect.rtw, 0);
+                // TODO - Do something with the dominant direction
+            });
         });
         this._cdfGenerator.iblSource = texture;
         this._cdfGenerator.renderWhenReady();

--- a/src/textureTools/textureTools.ts
+++ b/src/textureTools/textureTools.ts
@@ -83,11 +83,8 @@ export class TextureTools {
      */
     public renderDiffuseIBL(texture: BaseTexture): void {
         this._cdfGenerator.onGeneratedObservable.addOnce(() => {
-            this._cdfGenerator.findDominantDirection().then((direction) => {
-                this._iblDiffuseEffect.render(texture, this._cdfGenerator.getIcdfTexture());
-                this._blitCubeEffect.blit(this._iblDiffuseEffect.rtw, 0);
-                // TODO - Do something with the dominant direction
-            });
+            this._iblDiffuseEffect.render(texture, this._cdfGenerator.getIcdfTexture());
+            this._blitCubeEffect.blit(this._iblDiffuseEffect.rtw, 0);
         });
         this._cdfGenerator.iblSource = texture;
         this._cdfGenerator.renderWhenReady();


### PR DESCRIPTION
This PR mainly bumps the Babylon version so as to include dominant direction in irradiance.
However, I also fixed a shader compile error for irradiance and turned on super sampling which can have a big effect on irradiance at lower resolutions.